### PR TITLE
Add fsspec-based result store

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,32 @@
 [![codecov](https://codecov.io/github/cswartzvi/waypoint/graph/badge.svg?token=1o01x0xk7i)](https://codecov.io/github/cswartzvi/waypoint)
 
 Waypoint is a lightweight alternative to cloud-native orchestrators, giving scientists and engineers the flexibility to design and run workflows with full control — no vendor lock-in, no central server required.
+
+## Result storage
+
+Waypoint ships with a simple `ResultStore` protocol for persisting task outputs. An
+`FSSpecResultStore` implementation leverages [`fsspec`](https://filesystem-spec.readthedocs.io/) to read and write data to any supported filesystem.
+
+Install the optional dependency:
+
+```bash
+pip install "waypoint[fsspec]"
+```
+
+```python
+from waypoint.results import FSSpecResultStore
+
+store = FSSpecResultStore()
+store.write_bytes("output.bin", b"data")
+assert store.exists("output.bin")
+print(store.read_bytes("output.bin"))
+```
+
+You can also provide a custom filesystem:
+
+```python
+import fsspec
+
+fs = fsspec.filesystem("memory")
+store = FSSpecResultStore(fs)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
 logging = [
     "rich>=14.0.0",
 ]
+fsspec = [
+    "fsspec>=2024.6.1",
+]
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/src/waypoint/results.py
+++ b/src/waypoint/results.py
@@ -1,0 +1,55 @@
+"""Utilities for storing and retrieving task results."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Protocol
+
+
+class ResultStore(Protocol):
+    """Protocol for storing and retrieving task results."""
+
+    def write_bytes(self, path: str, data: bytes) -> None:
+        """Write bytes to the given path."""
+        ...
+
+    def read_bytes(self, path: str) -> bytes:
+        """Read bytes from the given path."""
+        ...
+
+    def exists(self, path: str) -> bool:
+        """Return ``True`` if the given path exists."""
+        ...
+
+
+class FSSpecResultStore(ResultStore):
+    """
+    A :class:`ResultStore` backed by an ``fsspec`` filesystem.
+
+    Args:
+        fs: Optional ``fsspec`` filesystem. If not provided, a local
+            filesystem is created.
+    """
+
+    def __init__(self, fs: Any | None = None) -> None:
+        if fs is None:
+            try:
+                fsspec = importlib.import_module("fsspec")
+            except ModuleNotFoundError as exc:  # pragma: no cover - optional dep
+                raise RuntimeError("fsspec is required to use FSSpecResultStore") from exc
+            fs = fsspec.filesystem("file")
+        self._fs: Any = fs
+
+    def write_bytes(self, path: str, data: bytes) -> None:
+        """Write ``data`` to ``path``."""
+        with self._fs.open(path, "wb") as file:
+            file.write(data)
+
+    def read_bytes(self, path: str) -> bytes:
+        """Read and return bytes from ``path``."""
+        with self._fs.open(path, "rb") as file:
+            return file.read()
+
+    def exists(self, path: str) -> bool:
+        """Return ``True`` if ``path`` exists."""
+        return self._fs.exists(path)


### PR DESCRIPTION
## Summary
- implement FSSpecResultStore using fsspec-backed filesystem
- document optional fsspec dependency and usage examples
- expose fsspec extra in project metadata

## Testing
- `ruff check src/waypoint/results.py`
- `mypy src/waypoint/results.py`
- `pyright src/waypoint/results.py`
- `PYTHONPATH=src pytest tests/test_flows.py`
- `PYTHONPATH=src pytest` *(fails: Rich library is required for logging in Waypoint; 'asyncio' marker unknown)*
- `pre-commit run --files src/waypoint/results.py README.md pyproject.toml` *(fails: pre-commit not installed and installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b8abb348148327b5e90d8ced6fdf95